### PR TITLE
1.0.5

### DIFF
--- a/VHDX/VHDX.psd1
+++ b/VHDX/VHDX.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'VHDX.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.0.0'
+	ModuleVersion = '1.0.1'
 	
 	# ID used to uniquely identify this module
 	GUID = 'a59182b4-2f77-44f2-bc12-323b53bc82ba'
@@ -55,19 +55,19 @@
 		PSData = @{
 			
 			# Tags applied to this module. These help with module discovery in online galleries.
-			# Tags = @()
+			Tags = @('VHDX')
 			
 			# A URL to the license for this module.
-			# LicenseUri = ''
+			LicenseUri = 'https://github.com/FriedrichWeinmann/VHDX/blob/master/LICENSE'
 			
 			# A URL to the main website for this project.
-			# ProjectUri = ''
+			ProjectUri = 'https://github.com/FriedrichWeinmann/VHDX'
 			
 			# A URL to an icon representing this module.
 			# IconUri = ''
 			
 			# ReleaseNotes of this module
-			# ReleaseNotes = ''
+			ReleaseNotes = 'https://github.com/FriedrichWeinmann/VHDX/blob/master/VHDX/changelog.md'
 			
 		} # End of PSData hashtable
 		

--- a/VHDX/VHDX.psd1
+++ b/VHDX/VHDX.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'VHDX.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.0.1'
+	ModuleVersion = '1.0.5'
 	
 	# ID used to uniquely identify this module
 	GUID = 'a59182b4-2f77-44f2-bc12-323b53bc82ba'
@@ -26,7 +26,7 @@
 	# Modules that must be imported into the global environment prior to importing
 	# this module
 	RequiredModules = @(
-		@{ ModuleName='PSFramework'; ModuleVersion='1.6.198' }
+		@{ ModuleName='PSFramework'; ModuleVersion='1.6.205' }
 	)
 	
 	# Assemblies that must be loaded prior to importing this module

--- a/VHDX/VHDX.psm1
+++ b/VHDX/VHDX.psm1
@@ -1,5 +1,5 @@
 ﻿$script:ModuleRoot = $PSScriptRoot
-$script:ModuleVersion = (Import-PowerShellDataFile -Path "$($script:ModuleRoot)\VHDX.psd1").ModuleVersion
+$script:ModuleVersion = (Import-PSFPowerShellDataFile -Path "$($script:ModuleRoot)\VHDX.psd1").ModuleVersion
 
 # Detect whether at some level dotsourcing was enforced
 $script:doDotSource = Get-PSFConfigValue -FullName VHDX.Import.DoDotSource -Fallback $false

--- a/VHDX/changelog.md
+++ b/VHDX/changelog.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
+
+## 1.0.1 (2021-09-01)
+
++ Fix: New-VHDX - UseShellExecute must be false for redirecting IO, fails on WinPS
+
 ## 1.0.0 (2021-05-21)
- - New: Some Stuff
- - Upd: Moar Stuff
- - Fix: Much Stuff
+ 
++ Initial release

--- a/VHDX/changelog.md
+++ b/VHDX/changelog.md
@@ -1,10 +1,11 @@
 ﻿# Changelog
 
-## ??? (2021-09-01)
+## 1.0.5 (2021-11-02)
 
 + Fix: New-Vhdx - UseShellExecute must be false for redirecting IO, fails on WinPS
 + Fix: New-Vhdx - Fails to dismount VHDX if copying of initial files & folders fails
 + Fix: New-Vhdx - Fails to copy files due to failure to identify correct volume
++ Fix: New-Vhdx - Fails to copy content due to delay in recognizing new driveletter
 + Fix: Invoke-Diskpart - Fails in JEA endpoints
 
 ## 1.0.0 (2021-05-21)

--- a/VHDX/changelog.md
+++ b/VHDX/changelog.md
@@ -1,9 +1,12 @@
 ﻿# Changelog
 
-## 1.0.1 (2021-09-01)
+## ??? (2021-09-01)
 
-+ Fix: New-VHDX - UseShellExecute must be false for redirecting IO, fails on WinPS
++ Fix: New-Vhdx - UseShellExecute must be false for redirecting IO, fails on WinPS
++ Fix: New-Vhdx - Fails to dismount VHDX if copying of initial files & folders fails
++ Fix: New-Vhdx - Fails to copy files due to failure to identify correct volume
++ Fix: Invoke-Diskpart - Fails in JEA endpoints
 
 ## 1.0.0 (2021-05-21)
- 
+
 + Initial release

--- a/VHDX/en-us/strings.psd1
+++ b/VHDX/en-us/strings.psd1
@@ -1,23 +1,24 @@
 ﻿# This is where the strings go, that are written by
 # Write-PSFMessage, Stop-PSFFunction or the PSFramework validation scriptblocks
 @{
-	'Add-VhdxContent.Adding.Item'			    = 'Adding file or folder: {0}' # $item
-	'Add-VhdxContent.Mount.Failed'			    = 'Failed to mount disk: {0}' # $resolvedPath
+	'Add-VhdxContent.Adding.Item'               = 'Adding file or folder: {0}' # $item
+	'Add-VhdxContent.Mount.Failed'              = 'Failed to mount disk: {0}' # $resolvedPath
 	'Add-VhdxContent.Volumes.Multiple.Error'    = 'More than one volume found on {0}. Currently, only disks with a single volume are supported.' # $resolvedPath
 	
-	'Dismount-Vhdx.Failed'					    = "Failed to mount disk '{0}' (Exit code: {1}).`nMessages:`n{2}`nErrors:`n{3}" # $resolvedPath, $result.ExitCode, ($result.Message -join "`n"), $result.Errors
-	'Dismount-Vhdx.Unmounting'				    = 'Dismounting disk: {0}' # $filePath
+	'Dismount-Vhdx.Failed'                      = "Failed to mount disk '{0}' (Exit code: {1}).`nMessages:`n{2}`nErrors:`n{3}" # $resolvedPath, $result.ExitCode, ($result.Message -join "`n"), $result.Errors
+	'Dismount-Vhdx.Unmounting'                  = 'Dismounting disk: {0}' # $filePath
 	
-	'Invoke-Diskpart.Message'				    = ' {0}' # $message
+	'Invoke-Diskpart.Message'                   = ' {0}' # $message
 	
-	'Mount-Vhdx.Failed'						    = "Failed to mount disk '{0}' (Exit code: {1}).`nMessages:`n{2}`nErrors:`n{3}" # $resolvedPath, $result.ExitCode, ($result.Message -join "`n"), $result.Errors
-	'Mount-Vhdx.Mounting'					    = 'Mounting disk: {0}' # $filePath
+	'Mount-Vhdx.Failed'                         = "Failed to mount disk '{0}' (Exit code: {1}).`nMessages:`n{2}`nErrors:`n{3}" # $resolvedPath, $result.ExitCode, ($result.Message -join "`n"), $result.Errors
+	'Mount-Vhdx.Mounting'                       = 'Mounting disk: {0}' # $filePath
 	
-	'New-Vhdx.Copying'						    = 'Adding content to new disk: {0}' # $inputItem
-	'New-Vhdx.CreateDisk.Failed'			    = 'Failed to create disk {0}: {1}' # $resolvedPath, $result.Errors
-	'New-Vhdx.PrepareDisk.Failed'			    = 'Failed to prepare & configure disk {0}: {1}' # $resolvedPath, $result.Errors
+	'New-Vhdx.Copying'                          = 'Adding content to new disk: {0} | Target: {1}' # $inputItem, $rootPath
+	'New-Vhdx.CreateDisk.Failed'                = 'Failed to create disk {0}: {1}' # $resolvedPath, $result.Errors
+	'New-Vhdx.PrepareDisk.Failed'               = 'Failed to prepare & configure disk {0}: {1}' # $resolvedPath, $result.Errors
+	'New-Vhdx.Volume.Timeout'                   = 'Timeout reached for identifying temporary volume letter. Any filetransfer will fail.' #
 	
-	'Remove-VhdxContent.Mount.Failed'		    = 'Failed to mount disk: {0}' # $resolvedPath
-	'Remove-VhdxContent.Removing.Item'		    = 'Removing file or folder: {0}' # $itemPath
+	'Remove-VhdxContent.Mount.Failed'           = 'Failed to mount disk: {0}' # $resolvedPath
+	'Remove-VhdxContent.Removing.Item'          = 'Removing file or folder: {0}' # $itemPath
 	'Remove-VhdxContent.Volumes.Multiple.Error' = 'More than one volume found on {0}. Currently, only disks with a single volume are supported.' # $resolvedPath
 }

--- a/VHDX/functions/Invoke-Diskpart.ps1
+++ b/VHDX/functions/Invoke-Diskpart.ps1
@@ -48,7 +48,7 @@
 		
 		while (-not $process.HasExited) { Start-Sleep -Milliseconds 100 }
 		
-		$messages = $process.StandardOutput.ReadToEnd() -split 'DISKPART>' | ForEach-Object Trim | Select-Object -Skip 1
+		$messages = $process.StandardOutput.ReadToEnd() -split 'DISKPART>' | ForEach-Object Trim | Microsoft.PowerShell.Utility\Select-Object -Skip 1
 		foreach ($message in $messages) {
 			Write-PSFMessage -String 'Invoke-Diskpart.Message' -StringValues $message
 		}

--- a/VHDX/functions/Invoke-Diskpart.ps1
+++ b/VHDX/functions/Invoke-Diskpart.ps1
@@ -27,6 +27,7 @@
 		Assert-Elevation -Cmdlet $PSCmdlet
 		
 		$startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+		$startInfo.UseShellExecute = $false
 		$startInfo.RedirectStandardError = $true
 		$startInfo.RedirectStandardInput = $true
 		$startInfo.RedirectStandardOutput = $true

--- a/VHDX/functions/New-Vhdx.ps1
+++ b/VHDX/functions/New-Vhdx.ps1
@@ -103,6 +103,7 @@
 		}
 		until ($volume.DriveLetter)
         $rootPath = '{0}:\' -f $volume.DriveLetter
+		$null = Get-PSProvider | Write-Output
     }
     process {
 		foreach ($inputItem in $Content) {

--- a/VHDX/functions/New-Vhdx.ps1
+++ b/VHDX/functions/New-Vhdx.ps1
@@ -67,6 +67,11 @@
         }
 
         $resolvedPath = Resolve-PSFPath -Path $Path -Provider FileSystem -SingleItem -NewChild
+		# Normalize path to avoid legacy-shortening of folder names breaking later comparisons
+		$parent = Split-Path -Path $resolvedPath
+		$fileName = Split-Path -Path $resolvedPath -Leaf
+		$resolvedPath = Join-Path -Path (Get-Item -Path $parent).FullName -ChildPath $fileName
+
 		$diskPartCommand = 'create vdisk file="{0}" maximum={1} type={2}' -f $resolvedPath, $Size.Megabyte, $typeMapping[$Type]
 		$result = Invoke-Diskpart -ArgumentList $diskPartCommand
 		
@@ -86,14 +91,25 @@
 			Stop-PSFFunction -String 'New-Vhdx.PrepareDisk.Failed' -StringValues $resolvedPath, $result.Errors -EnableException $true
         }
 
-        $disk = Get-Disk | Where-Object Location -EQ $resolvedPath
-        $volume = $disk | Get-Partition | Get-Volume
+		$start = Get-Date
+		do {
+			Start-Sleep -Milliseconds 200
+			$disk = Get-Disk | Where-Object Location -EQ $resolvedPath
+			$volume = $disk | Get-Partition | Get-Volume
+			if ($start.AddMinutes(1) -lt (Get-Date)) {
+				Write-PSFMessage -Level Warning -String 'New-Vhdx.Volume.Timeout'
+				break
+			}
+		}
+		until ($volume.DriveLetter)
         $rootPath = '{0}:\' -f $volume.DriveLetter
     }
     process {
 		foreach ($inputItem in $Content) {
-			Write-PSFMessage -String 'New-Vhdx.Copying' -StringValues $inputItem
-            Copy-Item -Path $inputItem -Destination $rootPath -Force -Recurse
+			Write-PSFMessage -String 'New-Vhdx.Copying' -StringValues $inputItem, $rootPath
+			Invoke-PSFProtectedCommand -ActionString 'New-Vhdx.Copying' -ActionStringValues $inputItem, $rootPath -Target $volume.DriveLetter -ScriptBlock {
+				Copy-Item -Path $inputItem -Destination $rootPath -Force -Recurse -ErrorAction Stop
+			} -PSCmdlet $PSCmdlet -Continue
         }
     }
 	end {

--- a/VHDX/tests/general/FileIntegrity.Exceptions.ps1
+++ b/VHDX/tests/general/FileIntegrity.Exceptions.ps1
@@ -31,7 +31,7 @@ $global:MayContainCommand = @{
 	"Write-Verbose" = @()
 	"Write-Warning" = @()
 	"Write-Error"  = @()
-	"Write-Output" = @()
+	"Write-Output" = @('New-Vhdx.ps1')
 	"Write-Information" = @()
 	"Write-Debug" = @()
 }


### PR DESCRIPTION
+ Fix: New-Vhdx - UseShellExecute must be false for redirecting IO, fails on WinPS
+ Fix: New-Vhdx - Fails to dismount VHDX if copying of initial files & folders fails
+ Fix: New-Vhdx - Fails to copy files due to failure to identify correct volume
+ Fix: New-Vhdx - Fails to copy content due to delay in recognizing new driveletter
+ Fix: Invoke-Diskpart - Fails in JEA endpoints